### PR TITLE
Fix `ApplicationHeaders.getHeaders()`

### DIFF
--- a/examples/src/main/java/com/flipkart/gjex/examples/helloworld/filter/AuthFilter.java
+++ b/examples/src/main/java/com/flipkart/gjex/examples/helloworld/filter/AuthFilter.java
@@ -41,7 +41,7 @@ public class AuthFilter extends GrpcFilter<HelloRequest, HelloReply> implements 
 	static final Metadata.Key AUTH_KEY = Metadata.Key.of("DUMMY_AUTH_TOKEN", Metadata.ASCII_STRING_MARSHALLER);
 
 	/** Flag to control authentication check*/
-	private final boolean isAuth = true;
+	private final boolean isAuth = false;
 
 	@Override
 	public GrpcFilter<HelloRequest, HelloReply> getInstance(){

--- a/examples/src/main/java/com/flipkart/gjex/examples/helloworld/filter/AuthFilter.java
+++ b/examples/src/main/java/com/flipkart/gjex/examples/helloworld/filter/AuthFilter.java
@@ -41,7 +41,7 @@ public class AuthFilter extends GrpcFilter<HelloRequest, HelloReply> implements 
 	static final Metadata.Key AUTH_KEY = Metadata.Key.of("DUMMY_AUTH_TOKEN", Metadata.ASCII_STRING_MARSHALLER);
 
 	/** Flag to control authentication check*/
-	private final boolean isAuth = false;
+	private final boolean isAuth = true;
 
 	@Override
 	public GrpcFilter<HelloRequest, HelloReply> getInstance(){

--- a/examples/src/main/java/com/flipkart/gjex/examples/helloworld/service/GreeterService.java
+++ b/examples/src/main/java/com/flipkart/gjex/examples/helloworld/service/GreeterService.java
@@ -124,11 +124,11 @@ public class GreeterService extends GreeterGrpc.GreeterImplBase implements Loggi
 		}
 	}
 
-	@Override
-	@Timed // the Timed annotation for publishing JMX metrics via MBean
-	@MethodFilters({LoggingFilter.class}) // Method level filters
-	@Traced(withSamplingRate=0.0f) // Start a new Trace or participate in a Client-initiated distributed trace
-	public StreamObserver<Ping> pingPong(StreamObserver<Pong> responseObserver) {
+    @Override
+    @Timed // the Timed annotation for publishing JMX metrics via MBean
+    @MethodFilters({LoggingFilter.class, AuthFilter.class}) // Method level filters
+    @Traced(withSamplingRate = 0.0f) // Start a new Trace or participate in a Client-initiated distributed trace
+    public StreamObserver<Ping> pingPong(StreamObserver<Pong> responseObserver) {
 
 		StreamObserver<Ping> requestObserver = new StreamObserver<Ping>() {
 			@Override

--- a/examples/src/main/java/com/flipkart/gjex/examples/helloworld/service/GreeterService.java
+++ b/examples/src/main/java/com/flipkart/gjex/examples/helloworld/service/GreeterService.java
@@ -18,6 +18,7 @@ package com.flipkart.gjex.examples.helloworld.service;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import com.flipkart.gjex.core.context.GJEXContext;
 import com.flipkart.gjex.examples.helloworld.filter.AuthFilter;
 import io.dropwizard.metrics5.annotation.Timed;
 import com.flipkart.gjex.core.filter.grpc.ApplicationHeaders;
@@ -29,12 +30,11 @@ import com.flipkart.gjex.core.tracing.Traced;
 import com.flipkart.gjex.examples.helloworld.bean.HelloBean;
 import com.flipkart.gjex.examples.helloworld.filter.LoggingFilter;
 
-import io.grpc.Metadata;
-import io.grpc.Status;
-import io.grpc.StatusException;
-import io.grpc.StatusRuntimeException;
+import io.grpc.*;
 import io.grpc.examples.helloworld.*;
 import io.grpc.stub.StreamObserver;
+
+import java.util.Optional;
 
 
 /**
@@ -126,7 +126,7 @@ public class GreeterService extends GreeterGrpc.GreeterImplBase implements Loggi
 
 	@Override
 	@Timed // the Timed annotation for publishing JMX metrics via MBean
-	@MethodFilters({LoggingFilter.class, AuthFilter.class}) // Method level filters
+	@MethodFilters({LoggingFilter.class}) // Method level filters
 	@Traced(withSamplingRate=0.0f) // Start a new Trace or participate in a Client-initiated distributed trace
 	public StreamObserver<Ping> pingPong(StreamObserver<Pong> responseObserver) {
 

--- a/guice/src/main/java/com/flipkart/gjex/grpc/interceptor/FilterInterceptor.java
+++ b/guice/src/main/java/com/flipkart/gjex/grpc/interceptor/FilterInterceptor.java
@@ -34,11 +34,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.validation.ConstraintViolationException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -96,15 +92,13 @@ public class FilterInterceptor implements ServerInterceptor, Logging {
                 }, headers)) {
             };
         }
-        List<GrpcFilter> grpcFilters = grpcFilterReferences.stream().map(GrpcFilter::getInstance).collect(Collectors.toList());
+        List<GrpcFilter> grpcFilters = grpcFilterReferences.stream().map(GrpcFilter::getInstance).toList();
 
         for (GrpcFilter filter : grpcFilters) {
-            if (filter != null) {
-                for (Metadata.Key key : filter.getForwardHeaderKeys()) {
-                    Object value = headers.get(key);
-                    if (value != null) {
-                        forwardHeaders.put(key, value);
-                    }
+            for (Metadata.Key key : filter.getForwardHeaderKeys()) {
+                Object value = headers.get(key);
+                if (value != null) {
+                    forwardHeaders.put(key, value);
                 }
             }
         }

--- a/guice/src/main/java/com/flipkart/gjex/grpc/interceptor/FilterInterceptor.java
+++ b/guice/src/main/java/com/flipkart/gjex/grpc/interceptor/FilterInterceptor.java
@@ -111,8 +111,6 @@ public class FilterInterceptor implements ServerInterceptor, Logging {
 
         Context contextWithHeaders = forwardHeaders.keys().isEmpty() ? null : Context.current().withValue(GJEXContext.getHeadersKey(), forwardHeaders);
 
-        info("Get Headers from Context" + GJEXContext.KEY_HEADERS.get(contextWithHeaders));
-
         ServerCall.Listener<Req> listener = next.startCall(new SimpleForwardingServerCall<Req, Res>(call) {
             @Override
             public void sendMessage(final Res response) {
@@ -161,7 +159,6 @@ public class FilterInterceptor implements ServerInterceptor, Logging {
             public void onMessage(Req request) {
                 Context previous = attachContext(contextWithHeaders);   // attaching headers to gRPC context
                 try {
-                    info("onMessage Get Headers from Context-" + GJEXContext.KEY_HEADERS.get());
                     grpcFilters.forEach(filter -> filter.doProcessRequest(request,requestParams));
                     super.onMessage(request);
                 }  finally  {

--- a/guice/src/main/java/com/flipkart/gjex/grpc/interceptor/FilterInterceptor.java
+++ b/guice/src/main/java/com/flipkart/gjex/grpc/interceptor/FilterInterceptor.java
@@ -92,7 +92,7 @@ public class FilterInterceptor implements ServerInterceptor, Logging {
                 }, headers)) {
             };
         }
-        List<GrpcFilter> grpcFilters = grpcFilterReferences.stream().map(GrpcFilter::getInstance).toList();
+        List<GrpcFilter> grpcFilters = grpcFilterReferences.stream().map(GrpcFilter::getInstance).collect(Collectors.toList());
 
         for (GrpcFilter filter : grpcFilters) {
             for (Metadata.Key key : filter.getForwardHeaderKeys()) {

--- a/guice/src/main/java/com/flipkart/gjex/grpc/service/GrpcServer.java
+++ b/guice/src/main/java/com/flipkart/gjex/grpc/service/GrpcServer.java
@@ -127,7 +127,7 @@ public class GrpcServer extends AbstractService implements Logging {
 
     public void registerServices(List<BindableService> services) {
         services.forEach(service -> this.grpcServerBuilder.addService(ServerInterceptors.intercept(service,
-                this.statusMetricInterceptor, this.tracingInterceptor, this.filterInterceptor)));
+            this.filterInterceptor, this.statusMetricInterceptor, this.tracingInterceptor)));
     }
 
 }


### PR DESCRIPTION
Return the configured headers from filters.

Fixes #91 