### PR TITLE
Common-Log format for access.log

### DIFF
--- a/core/src/main/java/com/flipkart/gjex/core/context/AccessLogContext.java
+++ b/core/src/main/java/com/flipkart/gjex/core/context/AccessLogContext.java
@@ -8,7 +8,9 @@ import org.apache.commons.text.StringSubstitutor;
 import java.lang.reflect.Field;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -58,7 +60,7 @@ public class AccessLogContext {
         }
 
         if (requestTime != null) {
-            String localDate = LocalDateTime.ofInstant(Instant.ofEpochMilli(requestTime), ZoneId.systemDefault()).toString();
+            String localDate = OffsetDateTime.ofInstant(Instant.ofEpochMilli(requestTime), ZoneId.systemDefault()).format(DateTimeFormatter.ISO_DATE_TIME);
             params.put("request-time", localDate);
         }
         params.put("thread", Thread.currentThread().getName());

--- a/core/src/main/java/com/flipkart/gjex/core/filter/grpc/AccessLogGrpcFilter.java
+++ b/core/src/main/java/com/flipkart/gjex/core/filter/grpc/AccessLogGrpcFilter.java
@@ -81,7 +81,8 @@ public class AccessLogGrpcFilter<R extends GeneratedMessageV3, S extends Generat
         accessLogContextBuilder = AccessLogContext.builder()
             .requestTime(startTime)
             .clientIp(requestParamsInput.getClientIp())
-            .resourcePath(requestParamsInput.getResourcePath());
+            .resourcePath(requestParamsInput.getResourcePath())
+            .method(requestParamsInput.getMethod());
 
         Map<String, String> headers = requestParamsInput.getMetadata().keys().stream()
             .collect(Collectors.toMap(String::toLowerCase, key ->
@@ -92,7 +93,7 @@ public class AccessLogGrpcFilter<R extends GeneratedMessageV3, S extends Generat
     }
 
     /**
-     * Placeholder method for processing response headers. Currently does not perform any operations.
+     * Placeholder method for processing response headers. Currently, does not perform any operations.
      *
      * @param responseHeaders The metadata associated with the gRPC response.
      */

--- a/core/src/main/java/com/flipkart/gjex/core/filter/grpc/GrpcFilterConfig.java
+++ b/core/src/main/java/com/flipkart/gjex/core/filter/grpc/GrpcFilterConfig.java
@@ -34,5 +34,5 @@ public class GrpcFilterConfig {
     private boolean enableAccessLogs = true;
 
     @JsonProperty("accessLogFormat")
-    private String accessLogFormat = "{clientIp} {resourcePath} {responseStatus} {contentLength} {responseTime}";
+    private String accessLogFormat = "{clientIp} - [{request-time}] \"{method} {resourcePath}\" {responseStatus} {contentLength} {responseTime}";
 }

--- a/core/src/main/java/com/flipkart/gjex/core/filter/http/HttpFilterConfig.java
+++ b/core/src/main/java/com/flipkart/gjex/core/filter/http/HttpFilterConfig.java
@@ -34,6 +34,6 @@ public class HttpFilterConfig {
   private boolean enableAccessLogs = true;
 
   @JsonProperty("accessLogFormat")
-  private String accessLogFormat = "{clientIp} \"{method} {resourcePath} {protocol}\" {responseStatus} {contentLength} {responseTime}";
+  private String accessLogFormat = "{clientIp} - [{request-time}] \"{method} {resourcePath} {protocol}\" {responseStatus} {contentLength} {responseTime} \"{referer}\" \"{userAgent}\"";
 
 }

--- a/examples/src/main/java/com/flipkart/gjex/examples/helloworld/service/GreeterService.java
+++ b/examples/src/main/java/com/flipkart/gjex/examples/helloworld/service/GreeterService.java
@@ -126,7 +126,7 @@ public class GreeterService extends GreeterGrpc.GreeterImplBase implements Loggi
 
     @Override
     @Timed // the Timed annotation for publishing JMX metrics via MBean
-    @MethodFilters({LoggingFilter.class, AuthFilter.class}) // Method level filters
+    @MethodFilters({LoggingFilter.class}) // Method level filters
     @Traced(withSamplingRate = 0.0f) // Start a new Trace or participate in a Client-initiated distributed trace
     public StreamObserver<Ping> pingPong(StreamObserver<Pong> responseObserver) {
 

--- a/examples/src/main/resources/hello_world_config.yml
+++ b/examples/src/main/resources/hello_world_config.yml
@@ -3,7 +3,7 @@ Grpc:
     server.executorThreads : 4
     filterConfig:
         enableAccessLogs: true
-        accessLogFormat: "{clientIp} {resourcePath} {contentLength} {responseStatus} {responseTime}"
+        accessLogFormat: '{clientIp} - [{request-time}] "{method} {resourcePath} GRPC" {responseStatus} {contentLength} {responseTime} "-" "-"'
 
 Dashboard:
     service.port: 9999

--- a/examples/src/main/resources/log4j2.xml
+++ b/examples/src/main/resources/log4j2.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration shutdownHook="disable">
     <Properties>
-        <Property name="log-path">logs</Property>
+        <Property name="log-path">/tmp/logs</Property>
     </Properties>
     <Appenders>
         <Console name="console-log" target="SYSTEM_OUT">
             <PatternLayout pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{5} %X - %msg%n"/>
         </Console>
-        <Console name="ACCESS-LOG" target="SYSTEM_OUT">
-            <PatternLayout pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{5} %X - %msg%n"/>
-        </Console>
+        <File name="access-log" fileName="${log-path}/access.log">
+            <PatternLayout pattern="%msg%n"/>
+        </File>
     </Appenders>
     <Loggers>
-        <Logger name="io.netty.channel" level="info" additivity="false">
-            <AppenderRef ref="ACCESS-LOG"/>
+        <Logger name="ACCESS-LOG" level="info" additivity="false">
+            <AppenderRef ref="access-log"/>
         </Logger>
         <Logger name="io.netty.channel" level="error" additivity="false">
             <AppenderRef ref="console-log"/>

--- a/guice/src/main/java/com/flipkart/gjex/grpc/interceptor/FilterInterceptor.java
+++ b/guice/src/main/java/com/flipkart/gjex/grpc/interceptor/FilterInterceptor.java
@@ -135,6 +135,7 @@ public class FilterInterceptor implements ServerInterceptor, Logging {
         RequestParams requestParams = RequestParams.builder()
                 .clientIp(getClientIp(call.getAttributes().get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR)))
                 .resourcePath(call.getMethodDescriptor().getFullMethodName().toLowerCase())
+                .method(call.getMethodDescriptor().getType().name())
                 .metadata(headers)
                 .build();
 


### PR DESCRIPTION
Example for #89

Sample `access.log`

```
localhost - [2024-08-10T18:49:32.885+05:30] "UNARY helloworld.greeter/sayhello GRPC" 0 27 223 "-" "-"
localhost - [2024-08-10T18:49:33.273+05:30] "UNARY helloworld.greeter/sayhello GRPC" 0 27 215 "-" "-"
localhost - [2024-08-10T18:49:33.635+05:30] "UNARY helloworld.greeter/sayhello GRPC" 0 27 219 "-" "-"
localhost - [2024-08-10T18:49:34.005+05:30] "UNARY helloworld.greeter/sayhello GRPC" 0 27 211 "-" "-"
localhost - [2024-08-10T18:49:34.363+05:30] "UNARY helloworld.greeter/sayhello GRPC" 0 27 211 "-" "-"
0:0:0:0:0:0:0:1 - [2024-08-10T18:49:36.879+05:30] "GET /api/hellocontrol1 HTTP/1.1" 200 23 28 "-" "PostmanRuntime/7.41.0"
0:0:0:0:0:0:0:1 - [2024-08-10T18:49:37.221+05:30] "GET /api/hellocontrol1 HTTP/1.1" 200 23 5 "-" "PostmanRuntime/7.41.0"
0:0:0:0:0:0:0:1 - [2024-08-10T18:49:37.844+05:30] "GET /api/hellocontrol1 HTTP/1.1" 200 23 6 "-" "PostmanRuntime/7.41.0"
0:0:0:0:0:0:0:1 - [2024-08-10T18:49:39.919+05:30] "GET /api/hellocontrol1 HTTP/1.1" 200 23 5 "-" "PostmanRuntime/7.41.0"
localhost - [2024-08-10T18:52:26.202+05:30] "BIDI_STREAMING helloworld.greeter/pingpong GRPC" 0 6 66 "-" "-"
localhost - [2024-08-10T18:52:28.512+05:30] "BIDI_STREAMING helloworld.greeter/pingpong GRPC" 0 6 1 "-" "-"
localhost - [2024-08-10T18:52:29.359+05:30] "BIDI_STREAMING helloworld.greeter/pingpong GRPC" 0 6 1 "-" "-"
localhost - [2024-08-10T18:52:36.561+05:30] "BIDI_STREAMING helloworld.greeter/pingpong GRPC" 0 6 9 "-" "-"
localhost - [2024-08-10T18:52:37.103+05:30] "BIDI_STREAMING helloworld.greeter/pingpong GRPC" 0 6 1 "-" "-"
localhost - [2024-08-10T18:52:37.434+05:30] "BIDI_STREAMING helloworld.greeter/pingpong GRPC" 0 6 1 "-" "-"

```