### PR TITLE
Bump jetty to 9.4.56.v20240826

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ subprojects {
                 jersey_freemarker       : 'org.glassfish.jersey.ext:jersey-mvc-freemarker:2.6',
                 servlet                 : 'javax.servlet:javax.servlet-api:3.1.0',
                 jackson                 : "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:${jacksonVersion}",
-                jetty_metrics           : 'io.dropwizard.metrics:metrics-jetty10:4.2.29',
+                jetty_metrics           : 'io.dropwizard.metrics:metrics-jetty9:4.2.29',
                 guice_validator         : 'ru.vyarus:guice-validator:1.2.0',
                 hibernate_validator     : 'org.hibernate:hibernate-validator:5.4.1.Final',
                 javax_el                : 'org.glassfish:javax.el:3.0.1-b08',

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'idea'
     id 'eclipse'
     id 'maven-publish'
+    id 'project-report'
 }
 
 
@@ -108,5 +109,7 @@ subprojects {
     }
 }
 
-
+htmlDependencyReport {
+    projects = project.allprojects
+}
 

--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ subprojects {
                 jersey_freemarker       : 'org.glassfish.jersey.ext:jersey-mvc-freemarker:2.6',
                 servlet                 : 'javax.servlet:javax.servlet-api:3.1.0',
                 jackson                 : "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:${jacksonVersion}",
-                jetty_metrics           : 'io.dropwizard.metrics:metrics-jetty9:4.2.29',
+                jetty_metrics           : 'io.dropwizard.metrics:metrics-jetty10:4.2.29',
                 guice_validator         : 'ru.vyarus:guice-validator:1.2.0',
                 hibernate_validator     : 'org.hibernate:hibernate-validator:5.4.1.Final',
                 javax_el                : 'org.glassfish:javax.el:3.0.1-b08',

--- a/grpc-jexpress-template/pom.xml
+++ b/grpc-jexpress-template/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <jetty.version>9.4.54.v20240208</jetty.version>
+        <jetty.version>10.0.24</jetty.version>
         <grpc.version>1.60.0</grpc.version>
         <protoc.version>3.25.5</protoc.version>
         <metrics-guice.version>5.0.1</metrics-guice.version>

--- a/grpc-jexpress-template/pom.xml
+++ b/grpc-jexpress-template/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <jetty.version>10.0.24</jetty.version>
+        <jetty.version>9.4.56.v20240826</jetty.version>
         <grpc.version>1.60.0</grpc.version>
         <protoc.version>3.25.5</protoc.version>
         <metrics-guice.version>5.0.1</metrics-guice.version>

--- a/guice/build.gradle
+++ b/guice/build.gradle
@@ -61,9 +61,9 @@ dependencies {
     implementation libraries.hystrix_metrics_stream
     implementation libraries.rxjava2
 
-    implementation 'org.eclipse.jetty:jetty-server:10.0.24'
-    implementation 'org.eclipse.jetty:jetty-servlet:10.0.24'
-    implementation 'org.eclipse.jetty:jetty-webapp:10.0.24'
+    implementation 'org.eclipse.jetty:jetty-server:9.4.56.v20240826'
+    implementation 'org.eclipse.jetty:jetty-servlet:9.4.56.v20240826'
+    implementation 'org.eclipse.jetty:jetty-webapp:9.4.56.v20240826'
     implementation 'io.opentracing.brave:brave-opentracing:0.31.3'
     implementation 'io.zipkin.reporter2:zipkin-sender-okhttp3:2.7.7'
 

--- a/guice/build.gradle
+++ b/guice/build.gradle
@@ -61,9 +61,9 @@ dependencies {
     implementation libraries.hystrix_metrics_stream
     implementation libraries.rxjava2
 
-    implementation 'org.eclipse.jetty:jetty-server:9.4.22.v20191022'
-    implementation 'org.eclipse.jetty:jetty-servlet:9.4.22.v20191022'
-    implementation 'org.eclipse.jetty:jetty-webapp:9.4.22.v20191022'
+    implementation 'org.eclipse.jetty:jetty-server:10.0.24'
+    implementation 'org.eclipse.jetty:jetty-servlet:10.0.24'
+    implementation 'org.eclipse.jetty:jetty-webapp:10.0.24'
     implementation 'io.opentracing.brave:brave-opentracing:0.31.3'
     implementation 'io.zipkin.reporter2:zipkin-sender-okhttp3:2.7.7'
 

--- a/guice/src/main/java/com/flipkart/gjex/guice/module/DashboardModule.java
+++ b/guice/src/main/java/com/flipkart/gjex/guice/module/DashboardModule.java
@@ -32,7 +32,7 @@ import com.flipkart.gjex.core.web.TracingResource;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.netflix.hystrix.contrib.metrics.eventstream.HystrixMetricsStreamServlet;
-import com.codahale.metrics.jetty9.InstrumentedHandler;
+import io.dropwizard.metrics.jetty10.InstrumentedHandler;
 import io.prometheus.metrics.exporter.servlet.javax.PrometheusMetricsServlet;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;

--- a/guice/src/main/java/com/flipkart/gjex/guice/module/DashboardModule.java
+++ b/guice/src/main/java/com/flipkart/gjex/guice/module/DashboardModule.java
@@ -32,7 +32,7 @@ import com.flipkart.gjex.core.web.TracingResource;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.netflix.hystrix.contrib.metrics.eventstream.HystrixMetricsStreamServlet;
-import io.dropwizard.metrics.jetty10.InstrumentedHandler;
+import com.codahale.metrics.jetty9.InstrumentedHandler;
 import io.prometheus.metrics.exporter.servlet.javax.PrometheusMetricsServlet;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;


### PR DESCRIPTION
Fixes `HTTP ERROR 500 java.lang.UnsupportedOperationException: Use .getMatched(String) instead` error  

Why 9.x ? 10.x doesn't support java8


Jetty Version | Servlet API | License | Java
-- | -- | -- | --
Jetty 9.4.x | 3.1 | JavaEE 8javax.servlet.* | Java 8
Jetty 10.0.x | 4.0 | JavaEE 8javax.servlet.* | Java 11+
Jetty 11.0.x | 5.0 | JakartaEE 9jakartaee.servlet.* | Java 11+

