### PR TITLE
Print Error Swallowed in `filter.doProcessResponse` 

### DIFF
--- a/guice/src/main/java/com/flipkart/gjex/http/interceptor/HttpFilterInterceptor.java
+++ b/guice/src/main/java/com/flipkart/gjex/http/interceptor/HttpFilterInterceptor.java
@@ -93,8 +93,12 @@ public class HttpFilterInterceptor implements javax.servlet.Filter, Logging {
                 responseHeaders.forEach(responseWrapper::setHeader);
             } finally {
                 // Allow the filters to process the response
-                filters.forEach(filter -> filter.doProcessResponse(responseWrapper));
-                response.getOutputStream().write(responseWrapper.getWrapperBytes());
+                try{
+                    filters.forEach(filter -> filter.doProcessResponse(responseWrapper));
+                    response.getOutputStream().write(responseWrapper.getWrapperBytes());
+                } catch (Exception e){
+                    error("Error while doProcessResponse", e);
+                }
             }
 
         } else {

--- a/guice/src/main/java/com/flipkart/gjex/http/interceptor/HttpFilterInterceptor.java
+++ b/guice/src/main/java/com/flipkart/gjex/http/interceptor/HttpFilterInterceptor.java
@@ -95,7 +95,10 @@ public class HttpFilterInterceptor implements javax.servlet.Filter, Logging {
                 // Allow the filters to process the response
                 try{
                     filters.forEach(filter -> filter.doProcessResponse(responseWrapper));
-                    response.getOutputStream().write(responseWrapper.getWrapperBytes());
+                    try (var outputStream = response.getOutputStream()) {
+                        outputStream.write(responseWrapper.getWrapperBytes());
+                        outputStream.flush();
+                    }
                 } catch (Exception e){
                     error("Error while doProcessResponse", e);
                 }

--- a/guice/src/main/java/com/flipkart/gjex/http/interceptor/HttpFilterInterceptor.java
+++ b/guice/src/main/java/com/flipkart/gjex/http/interceptor/HttpFilterInterceptor.java
@@ -95,10 +95,7 @@ public class HttpFilterInterceptor implements javax.servlet.Filter, Logging {
                 // Allow the filters to process the response
                 try{
                     filters.forEach(filter -> filter.doProcessResponse(responseWrapper));
-                    try (var outputStream = response.getOutputStream()) {
-                        outputStream.write(responseWrapper.getWrapperBytes());
-                        outputStream.flush();
-                    }
+                    response.getOutputStream().write(responseWrapper.getWrapperBytes());
                 } catch (Exception e){
                     error("Error while doProcessResponse", e);
                 }


### PR DESCRIPTION
Fixes error that is swallowed in `filter.doProcessResponse`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in HTTP filter interceptor
	- Added error logging for exceptions during response processing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->