### PR TITLE
Allow workflow_dispatch for SNAPSHOT Version Only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      
+      # Add step to read version and check if SNAPSHOT
+      - name: Check version for workflow_dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          VERSION=$(grep "def gJEXVersion = " build.gradle | cut -d"'" -f2)
+          if [[ ! $VERSION =~ .*SNAPSHOT$ ]]; then
+            echo "Error: Manual workflow runs are only allowed for SNAPSHOT versions"
+            echo "Current version: $VERSION"
+            exit 1
+          fi
+          echo "Version $VERSION is a SNAPSHOT version, proceeding with publish"
+
       - name: Set up Java
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the publishing workflow with an additional step that validates the package version before release, ensuring only valid snapshot versions proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->